### PR TITLE
Update README usage for uv

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,34 @@ The project is implemented based on Torch Lightning.
 
 Install the dependencies with [uv](https://github.com/astral-sh/uv):
 ```bash
-uv pip install -e .
+uv sync
 ```
+
+### Typical `uv` commands
+
+`uv` manages dependencies declared in `pyproject.toml` and keeps the
+`uv.lock` file in sync.
+
+- **Add a runtime package**
+  ```bash
+  uv add <package>
+  ```
+
+- **Add a development package**
+  ```bash
+  uv add --dev <package>
+  ```
+
+- **Remove a package**
+  ```bash
+  uv remove <package>
+  ```
+
+- **Install dev dependencies and run tests**
+  ```bash
+  uv sync
+  pytest
+  ```
 
 The config file is in ml_prototype/config/transformer_lm.yaml.
 


### PR DESCRIPTION
## Summary
- document basic uv workflow for managing dependencies

## Test Plan
- `pytest -q` *(fails: ModuleNotFoundError for torch)*

------
https://chatgpt.com/codex/tasks/task_b_683d1535344c8320b1a8b155404ffba7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated installation instructions to use `uv sync` for dependency installation.
  - Added a new section with typical `uv` command examples for managing packages and running tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->