### PR TITLE
Add dpo dataset conversion and lora dpo config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,3 +193,6 @@ ml_prototype/pipelines/**
 # Temp
 test.py
 .DS_Store
+
+# Wandb
+**/wandb/*

--- a/ml_prototype/post_training/Llama-3.2-1B-Instruct/lora_dpo_single_device.yaml
+++ b/ml_prototype/post_training/Llama-3.2-1B-Instruct/lora_dpo_single_device.yaml
@@ -49,6 +49,7 @@ save_adapter_weights_only: False
 dataset:
   _component_: torchtune.datasets.stack_exchange_paired_dataset
   source: john02171574/reward-bench-2-converted
+  data_dir: /data/
 seed: null
 shuffle: True
 batch_size: 4

--- a/ml_prototype/post_training/Llama-3.2-1B-Instruct/lora_dpo_single_device.yaml
+++ b/ml_prototype/post_training/Llama-3.2-1B-Instruct/lora_dpo_single_device.yaml
@@ -47,12 +47,12 @@ save_adapter_weights_only: False
 
 # Dataset and Sampler
 dataset:
-  _component_: torchtune.datasets.stack_exchange_paired_dataset
+  _component_: torchtune.datasets.preference_dataset
   source: john02171574/reward-bench-2-converted
-  data_dir: /data/
+  split: rl
 seed: null
 shuffle: True
-batch_size: 4
+batch_size: 2  # 2 is the max batch size for single 4090 GPU
 
 # Optimizer and Scheduler
 optimizer:
@@ -62,15 +62,15 @@ optimizer:
   lr: 5e-5
 lr_scheduler:
   _component_: torchtune.training.lr_schedulers.get_cosine_schedule_with_warmup
-  num_warmup_steps: 100
+  num_warmup_steps: 500
 
 loss:
   _component_: torchtune.rlhf.loss.DPOLoss
 
 # Training
-epochs: 1
+epochs: 3
 max_steps_per_epoch: 1000
-gradient_accumulation_steps: 8  # Use to increase effective batch size
+gradient_accumulation_steps: 32  # Use to increase effective batch size
 compile: False  # torch.compile the model + loss, True increases speed + decreases memory
 
 # Logging

--- a/ml_prototype/post_training/Llama-3.2-1B-Instruct/lora_dpo_single_device.yaml
+++ b/ml_prototype/post_training/Llama-3.2-1B-Instruct/lora_dpo_single_device.yaml
@@ -1,0 +1,92 @@
+# Config for single device LoRA DPO alignment in lora_dpo_single_device.py
+# using a Llama2 7B model
+#
+# This config assumes that you've run the following command before launching
+# this run:
+#   tune download meta-llama/Meta-Llama-3.1-8B-Instruct --output-dir /tmp/Meta-Llama-3.1-8B-Instruct --ignore-patterns "original/consolidated.00.pth"
+#
+# To launch on a single device, run the following command from root:
+#   tune run lora_dpo_single_device --config llama3_1/8B_lora_dpo_single_device
+#
+# You can add specific overrides through the command line. For example
+# to override the checkpointer directory while launching training
+# you can run:
+#   tune run lora_dpo_single_device --config llama3_1/8B_lora_dpo_single_device checkpointer.checkpoint_dir=<YOUR_CHECKPOINT_DIR>
+#
+# This config works only for training on single device.
+
+output_dir: /workspace/models/Llama-3.2-1B-Instruct-DPO # /tmp may be deleted by your system. Change it to your preference.
+
+# Model Arguments
+model:
+  _component_: torchtune.models.llama3_2.lora_llama3_2_1b
+  lora_attn_modules: ['q_proj', 'v_proj', 'output_proj']
+  apply_lora_to_mlp: True
+  apply_lora_to_output: False
+  lora_rank: 8  # higher increases accuracy and memory
+  lora_alpha: 16  # usually alpha=2*rank
+  lora_dropout: 0.0
+
+# Tokenizer
+tokenizer:
+  _component_: torchtune.models.llama3.llama3_tokenizer
+  path: /workspace/models/Llama-3.2-1B-Instruct/original/tokenizer.model
+  max_seq_len: 1024 # higher increases memory
+
+checkpointer:
+  _component_: torchtune.training.FullModelHFCheckpointer
+  checkpoint_dir: /workspace/models/Llama-3.2-1B-Instruct
+  checkpoint_files: [
+    model.safetensors
+  ]
+  recipe_checkpoint: null
+  output_dir: ${output_dir}
+  model_type: LLAMA3_2
+resume_from_checkpoint: False
+save_adapter_weights_only: False
+
+# Dataset and Sampler
+dataset:
+  _component_: torchtune.datasets.stack_exchange_paired_dataset
+  source: john02171574/reward-bench-2-converted
+seed: null
+shuffle: True
+batch_size: 4
+
+# Optimizer and Scheduler
+optimizer:
+  _component_: torch.optim.AdamW
+  fused: True
+  weight_decay: 0.001
+  lr: 5e-5
+lr_scheduler:
+  _component_: torchtune.training.lr_schedulers.get_cosine_schedule_with_warmup
+  num_warmup_steps: 100
+
+loss:
+  _component_: torchtune.rlhf.loss.DPOLoss
+
+# Training
+epochs: 1
+max_steps_per_epoch: 1000
+gradient_accumulation_steps: 8  # Use to increase effective batch size
+compile: False  # torch.compile the model + loss, True increases speed + decreases memory
+
+# Logging
+metric_logger:
+  # _component_: torchtune.training.metric_logging.DiskLogger
+  # log_dir: ${output_dir}/logs
+  _component_: torchtune.training.metric_logging.WandBLogger
+  project: post-training
+  name: llama-3.2-1b-lora-dpo-single-device
+log_every_n_steps: 1
+log_peak_memory_stats: True
+log_level: INFO  # DEBUG, WARN, etc.
+
+# Environment
+device: cuda
+dtype: bf16
+
+# Memory management
+enable_activation_checkpointing: True  # True reduces memory
+enable_activation_offloading: False  # True reduces memory

--- a/ml_prototype/post_training/Llama-3.2-1B-Instruct/lora_single_device.yaml
+++ b/ml_prototype/post_training/Llama-3.2-1B-Instruct/lora_single_device.yaml
@@ -1,0 +1,120 @@
+# Config for single device LoRA finetuning in lora_finetune_single_device.py
+# using a Llama3.1 8B Instruct model
+#
+# This config assumes that you've run the following command before launching
+# this run:
+#   tune download meta-llama/Meta-Llama-3.1-8B-Instruct --output-dir /tmp/Meta-Llama-3.1-8B-Instruct --ignore-patterns "original/consolidated.00.pth"
+#
+# To launch on a single device, run the following command from root:
+#   tune run lora_finetune_single_device --config llama3_1/8B_lora_single_device
+#
+# You can add specific overrides through the command line. For example
+# to override the checkpointer directory while launching training
+# you can run:
+#   tune run lora_finetune_single_device --config llama3_1/8B_lora_single_device checkpointer.checkpoint_dir=<YOUR_CHECKPOINT_DIR>
+#
+# This config works only for training on single device.
+
+
+output_dir: /tmp/torchtune/llama3_1_8B/lora_single_device # /tmp may be deleted by your system. Change it to your preference.
+
+# Model Arguments
+model:
+  _component_: torchtune.models.llama3_1.lora_llama3_1_8b
+  lora_attn_modules: ['q_proj', 'v_proj', 'output_proj']
+  apply_lora_to_mlp: True
+  apply_lora_to_output: False
+  lora_rank: 8  # higher increases accuracy and memory
+  lora_alpha: 16  # usually alpha=2*rank
+  lora_dropout: 0.0
+
+# Tokenizer
+tokenizer:
+  _component_: torchtune.models.llama3.llama3_tokenizer
+  path: /tmp/Meta-Llama-3.1-8B-Instruct/original/tokenizer.model
+  max_seq_len: null
+
+checkpointer:
+  _component_: torchtune.training.FullModelHFCheckpointer
+  checkpoint_dir: /tmp/Meta-Llama-3.1-8B-Instruct/
+  checkpoint_files: [
+    model-00001-of-00004.safetensors,
+    model-00002-of-00004.safetensors,
+    model-00003-of-00004.safetensors,
+    model-00004-of-00004.safetensors
+  ]
+  recipe_checkpoint: null
+  output_dir: ${output_dir}
+  model_type: LLAMA3
+resume_from_checkpoint: False
+save_adapter_weights_only: False
+
+# Dataset and Sampler
+dataset:
+  _component_: torchtune.datasets.alpaca_cleaned_dataset
+  packed: False  # True increases speed
+seed: null
+shuffle: True
+batch_size: 2
+
+# Optimizer and Scheduler
+optimizer:
+  _component_: torch.optim.AdamW
+  fused: True
+  weight_decay: 0.01
+  lr: 3e-4
+lr_scheduler:
+  _component_: torchtune.training.lr_schedulers.get_cosine_schedule_with_warmup
+  num_warmup_steps: 100
+
+loss:
+  _component_: torch.nn.CrossEntropyLoss
+
+# Training
+epochs: 1
+max_steps_per_epoch: null
+gradient_accumulation_steps: 8  # Use to increase effective batch size
+clip_grad_norm: null
+compile: False  # torch.compile the model + loss, True increases speed + decreases memory
+
+# Logging
+metric_logger:
+  _component_: torchtune.training.metric_logging.DiskLogger
+  log_dir: ${output_dir}/logs
+log_every_n_steps: 1
+log_peak_memory_stats: True
+log_level: INFO  # DEBUG, WARN, etc.
+
+# Environment
+device: cuda
+dtype: bf16
+
+# Activations Memory
+enable_activation_checkpointing: True  # True reduces memory
+enable_activation_offloading: False  # True reduces memory
+
+
+# Profiler (disabled)
+profiler:
+  _component_: torchtune.training.setup_torch_profiler
+  enabled: False
+
+  #Output directory of trace artifacts
+  output_dir: ${output_dir}/profiling_outputs
+
+  #`torch.profiler.ProfilerActivity` types to trace
+  cpu: True
+  cuda: True
+
+  #trace options passed to `torch.profiler.profile`
+  profile_memory: False
+  with_stack: False
+  record_shapes: True
+  with_flops: False
+
+  # `torch.profiler.schedule` options:
+  # wait_steps -> wait, warmup_steps -> warmup, active_steps -> active, num_cycles -> repeat
+  wait_steps: 5
+  warmup_steps: 3
+  active_steps: 2
+  num_cycles: 1

--- a/ml_prototype/post_training/scripts/dpo_data_process.ipynb
+++ b/ml_prototype/post_training/scripts/dpo_data_process.ipynb
@@ -1,0 +1,176 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Prepare the data for DPO training using reward-bench-2 from allenai/reward-bench-2\n",
+    "\n",
+    "Once converted, this dataset can use the following config to train the DPO model:\n",
+    "\n",
+    "```yaml\n",
+    "dataset:\n",
+    "  _component_: torchtune.datasets.stack_exchange_paired_dataset\n",
+    "  source: john02171574/reward-bench-2-converted\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of rows: 1865\n",
+      "Number of columns: 10\n",
+      "Number of unique values in the 'prompt' column: 1864\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 1865/1865 [00:00<00:00, 24031.29it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'chosen': [{'content': 'Hi do you know how to fix Codeium defaule setting that is responsible for this  [ERROR]: [deadline_exceeded] context deadline exceeded', 'role': 'user'}, {'content': \"Certainly! The error `[ERROR]: [deadline_exceeded] context deadline exceeded` typically indicates that the code generation process in Codeium (or another similar AI coding assistant) has timed out because it took too long to generate a response.\\n\\nHere are some steps you can take to address this issue:\\n\\n### 1. **Increase Timeout Settings:**\\n   - **Codeium**: Unfortunately, Codeium does not have an official UI setting to increase the timeout. However, you can try to simplify your code or use more efficient algorithms to reduce the time required.\\n   - **General Tips**: If you're working on a complex task, consider breaking it down into smaller parts or optimizing your code.\\n\\n### 2. **Optimize Your Code:**\\n   - Ensure your code is as optimized as possible. This might involve:\\n     - Using more efficient algorithms.\\n     - Reducing the complexity of your code.\\n     - Utilizing built-in functions and libraries that are known to be fast.\\n\\n### 3. **Check for Infinite Loops:**\\n   - Make sure there are no infinite loops or recursive calls that might be causing the process to hang indefinitely.\\n\\n### 4. **Use Asynchronous Operations:**\\n   - If applicable, use asynchronous operations to avoid blocking the main thread while waiting for a response from Codeium.\\n\\n### 5. **Limit the Scope of the Task:**\\n   - If the task is too large, break it down into smaller tasks and handle them one by one.\\n\\n### 6. **Restart Codeium:**\\n   - Sometimes, restarting the Codeium application can resolve temporary issues.\\n\\n### 7. **Check for Known Issues:**\\n   - Check if there are any known issues with Codeium that are being tracked by their support team. You can also reach out to their support for specific advice.\\n\\n### 8. **Update Codeium:**\\n   - Ensure that you are using the latest version of Codeium, as newer versions often include bug fixes and performance improvements.\\n\\nIf none of these steps resolve the issue, you might want to contact Codeium's support team for further assistance. They can provide more specific guidance based on your particular use case.\\n\\nLet me know if you need more specific advice or if you encounter any other issues!\", 'role': 'assistant'}], 'rejected': [{'content': 'Hi do you know how to fix Codeium defaule setting that is responsible for this  [ERROR]: [deadline_exceeded] context deadline exceeded', 'role': 'user'}, {'content': 'To resolve the \"deadline_exceeded\" error in Codeium, you can try the following steps to adjust the settings for increased time and resources allocation:\\n\\n1. Change the default timeout:\\n   By default, Codeium has a 5-second timeout. To increase the timeout, you can add the following command to your prompt:\\n\\n   ```\\n   /timeout 30s\\n   ```\\n   This sets the timeout to 30 seconds. You can adjust the time according to your needs.\\n\\n2. Increase the number of iterations:\\n   By default, Codeium limits the number of iterations to 15. To increase the number of iterations, you can add the following command to your prompt:\\n\\n   ```\\n   /iterations 30\\n   ```\\n   This sets the number of iterations to 30. You can adjust the number of iterations according to your needs.\\n\\n3. Adjust the concurrency level:\\n   By default, Codeium runs solutions in parallel with a concurrency level of 4. To change the concurrency level, you can add the following command to your prompt:\\n\\n   ```\\n   /concurrency 8\\n   ```\\n   This sets the concurrency level to 8, which means Codeium will run solutions in parallel on 8 threads.\\n\\n4. Manage the code length:\\n   If your code length exceeds the limit, you can split your solution into smaller functions/methods and call them as needed. The maximum code length is 128KB.\\n\\n5. Use a more specific prompt:\\n   Providing a clear, specific prompt helps Codeium generate the desired code accurately. For instance, provide input examples, desired output examples, and any other relevant details.\\n\\n6. Debug and optimize:\\n   After generating code, try to understand the generated output and optimize it if necessary. You can also refer to the `/explanation` command to get detailed information about the generated code.\\n\\n7. Update Codeium:\\n   Make sure you have the latest version of Codeium installed. You can update Codeium using pip:\\n\\n   ```\\n   pip install --upgrade codeium\\n   ```', 'role': 'assistant'}]}\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "362b502ba5c84a808edbb3b987fa7ad6",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Uploading the dataset shards:   0%|          | 0/1 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2d3b046de39f4222a76c83b53e5a4488",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Creating parquet from Arrow format:   0%|          | 0/2 [00:00<?, ?ba/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "CommitInfo(commit_url='https://huggingface.co/datasets/john02171574/reward-bench-2-converted/commit/059a9434fda5abf521927093f47f0f0d59e60668', commit_message='Upload dataset', commit_description='', oid='059a9434fda5abf521927093f47f0f0d59e60668', pr_url=None, repo_url=RepoUrl('https://huggingface.co/datasets/john02171574/reward-bench-2-converted', endpoint='https://huggingface.co', repo_type='dataset', repo_id='john02171574/reward-bench-2-converted'), pr_revision=None, pr_num=None)"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "## Load the lvwerra/stack-exchange-paired dataset and only keep 1% of the data\n",
+    "import datasets\n",
+    "from huggingface_hub import login\n",
+    "from tqdm import tqdm\n",
+    "\n",
+    "login(token=\"xxx\")\n",
+    "\n",
+    "# Load the dataset\n",
+    "dataset = datasets.load_dataset(\"allenai/reward-bench-2\", split=\"test\")\n",
+    "\n",
+    "# Show some stats\n",
+    "print(f\"Number of rows: {len(dataset)}\")\n",
+    "print(f\"Number of columns: {len(dataset[0].keys())}\")\n",
+    "print(f\"Number of unique values in the 'prompt' column: {len(dataset.unique('prompt'))}\")\n",
+    "\n",
+    "# Convert each row to the format of DPO\n",
+    "def convert_to_dpo(sample):\n",
+    "    if sample[\"chosen\"] is None or sample[\"rejected\"] is None:\n",
+    "        return None\n",
+    "    \n",
+    "    return {\n",
+    "        \"chosen\": [\n",
+    "            {\n",
+    "                \"role\": \"user\",\n",
+    "                \"content\": sample[\"prompt\"],\n",
+    "            },\n",
+    "            {\n",
+    "                \"role\": \"assistant\",\n",
+    "                \"content\": sample[\"chosen\"][0],\n",
+    "            },\n",
+    "        ],\n",
+    "        \"rejected\": [\n",
+    "            {\n",
+    "                \"role\": \"user\",\n",
+    "                \"content\": sample[\"prompt\"],\n",
+    "            },\n",
+    "            {\n",
+    "                \"role\": \"assistant\",\n",
+    "                \"content\": sample[\"rejected\"][0],\n",
+    "            },\n",
+    "        ],\n",
+    "    }\n",
+    "\n",
+    "# Apply the conversion to the dataset\n",
+    "converted_dataset = []\n",
+    "for sample in tqdm(dataset):\n",
+    "    converted_dataset.append(convert_to_dpo(sample))\n",
+    "\n",
+    "# Filter out None values and create a new dataset\n",
+    "converted_dataset = datasets.Dataset.from_list([sample for sample in converted_dataset if sample is not None])\n",
+    "\n",
+    "# Show the result dataset\n",
+    "print(converted_dataset[0])\n",
+    "\n",
+    "# Save the dataset to a jsonl file\n",
+    "# dataset.to_json(\"reward-bench-2.jsonl\", orient=\"records\", lines=True)\n",
+    "\n",
+    "# Upload the dataset to huggingface with account john02171574 as the name reward-bench-2\n",
+    "converted_dataset.push_to_hub(\"john02171574/reward-bench-2-converted\")\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "ml",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
## Summary
1. Add the script to convert dataset to DPO format.
Once converted, this dataset can use the following config to train the DPO model:

```yaml
dataset:
  _component_: torchtune.datasets.stack_exchange_paired_dataset
  source: john02171574/reward-bench-2-converted
```
2. Add two configs for lora.

## Test Plan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added configuration files for single-device LoRA DPO training with Llama 3.2 1B and LoRA finetuning with Llama 3.1 8B Instruct models.
	- Introduced a Jupyter notebook for processing and converting the "reward-bench-2" dataset for DPO training, including upload to Hugging Face Hub.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->